### PR TITLE
Added utility and helper functions to Property and SubmodelElement

### DIFF
--- a/src/libaas/basyx/base/valuetypedefs.h
+++ b/src/libaas/basyx/base/valuetypedefs.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include <basyx/util/string_view/string_view.hpp>
+
 namespace basyx {
 namespace detail
 {
@@ -17,10 +19,15 @@ namespace detail
 	template<> struct data_type_def<uint32_t> { static constexpr char value_type[] = "unsignedInt"; };
 	template<> struct data_type_def<int64_t> { static constexpr char value_type[] = "long"; };
 	template<> struct data_type_def<uint64_t> { static constexpr char value_type[] = "unsignedLong"; };
-	template<> struct data_type_def<std::string> { static constexpr char value_type[] = "string"; };
 	template<> struct data_type_def<float> { static constexpr char value_type[] = "float"; };
 	template<> struct data_type_def<double> { static constexpr char value_type[] = "double"; };
 	template<> struct data_type_def<bool> { static constexpr char value_type[] = "boolean"; };
+	template<> struct data_type_def<std::string> { static constexpr char value_type[] = "string"; };
+
+	template<typename T> struct data_type_map { using value_type_t = T; };
+	template<> struct data_type_map<std::string> { using value_type_t = std::string; };
+	template<> struct data_type_map<const char *> { using value_type_t = std::string; };
+	template<> struct data_type_map<util::string_view> { using value_type_t = std::string; };
 
 };
 }

--- a/src/libaas/basyx/submodelelement/property.h
+++ b/src/libaas/basyx/submodelelement/property.h
@@ -2,75 +2,154 @@
 
 #include <basyx/base/valuetypedefs.h>
 
-#include <basyx/submodelelement/dataelement.h>
 #include <basyx/langstringset.h>
 #include <basyx/modeltype.h>
 #include <basyx/serialization/serializable.h>
+#include <basyx/submodelelement/dataelement.h>
 
 #include <basyx/util/string_view/string_view.hpp>
 
+#include <sstream>
 #include <string>
 #include <type_traits>
 
-namespace basyx
-{
+namespace basyx {
 
-class property_base : public DataElement, private ModelType<ModelTypes::Property>
-{
+class property_base : public DataElement, private ModelType<ModelTypes::Property> {
 public:
-	property_base(util::string_view idShort) : DataElement(idShort) {};
-	virtual ~property_base() = default;
+    property_base(util::string_view idShort)
+        : DataElement(idShort) {};
+    virtual ~property_base() = default;
+
 public:
-	virtual util::string_view get_value_type() const = 0;
+    virtual util::string_view get_value_type() const = 0;
 
-	virtual const util::optional<Reference> & get_value_id() const = 0;
-	virtual void set_value_id(const Reference & reference) = 0;
+    virtual const util::optional<Reference>& get_value_id() const = 0;
+    virtual void set_value_id(const Reference& reference) = 0;
 
-	template<typename DataType>
-	Property<DataType> * cast() { return dynamic_cast<Property<DataType>>(this); };
+    virtual const util::optional<std::string> get_value_as_string() const = 0;
+    virtual bool set_value_from_string(util::string_view value) = 0;
+
+    template <typename DataType>
+    Property<DataType>* cast() { return dynamic_cast<Property<DataType>*>(this); };
 };
 
-template<typename DataType>
-class Property : 
-	public property_base, 
-	private serialization::Serializable<Property<DataType>>,
-	private Referable::Copyable<Property<DataType>>
-{
+template <typename DataType>
+class Property : public property_base,
+                 private serialization::Serializable<Property<DataType>>,
+                 private Referable::Copyable<Property<DataType>> {
 private:
-	util::optional<DataType> value;
-	util::optional<Reference> valueId;
+    util::optional<DataType> value;
+    util::optional<Reference> valueId;
+
 public:
-	Property(util::string_view idShort) : property_base(idShort) {};
+    Property(util::string_view idShort)
+        : property_base(idShort) {};
 
-	template<typename U=DataType>
-	Property(util::string_view idShort, U && u) : property_base(idShort), value(std::forward<U>(u)) {};
+    template <typename U = DataType>
+    Property(util::string_view idShort, U&& u)
+        : property_base(idShort)
+        , value(std::forward<U>(u)) {};
 
-	//// Enable string_view constructor for DataType == std::string
-	//template <typename U = DataType, std::enable_if_t<std::is_same<DataType, std::string>::value, bool> = true>
-	//Property(util::string_view idShort, util::string_view value)
-	//	: DataElement(idShort), value(value.to_string())
-	//{
-	//};
+    //// Enable string_view constructor for DataType == std::string
+    //template <typename U = DataType, std::enable_if_t<std::is_same<DataType, std::string>::value, bool> = true>
+    //Property(util::string_view idShort, util::string_view value)
+    //	: DataElement(idShort), value(value.to_string())
+    //{
+    //};
 
-	Property(const Property&) = default;
-	Property& operator=(const Property&) = default;
+    Property(const Property&) = default;
+    Property& operator=(const Property&) = default;
 
-	Property(Property&&) = default;
-	Property& operator=(Property&&) = default;
+    Property(Property&&) = default;
+    Property& operator=(Property&&) = default;
 
-	~Property() = default;
+    ~Property() = default;
+
 public:
-	const util::optional<Reference> & get_value_id() const override { return this->valueId; }
-	void set_value_id(const Reference & reference) override { this->valueId = reference; };
+    const util::optional<Reference>& get_value_id() const override { return this->valueId; }
+    void set_value_id(const Reference& reference) override { this->valueId = reference; };
 
-	util::string_view get_value_type() const override { return detail::data_type_def<DataType>::value_type; };
+    util::string_view get_value_type() const override { return detail::data_type_def<DataType>::value_type; };
 
-	const util::optional<DataType> & get_value() const { return this->value; };
+    const util::optional<DataType>& get_value() const { return this->value; };
 
-	template<typename U = DataType>
-	void set_value(U && value) {
-		this->value.emplace(std::forward<U>(value));
-	};
+    const util::optional<std::string> get_value_as_string() const override;
+    bool set_value_from_string(util::string_view value) override;
+
+    template <typename U = DataType>
+    void set_value(U&& value)
+    {
+        this->value.emplace(std::forward<U>(value));
+    };
+};
+
+class PropertyHelper {
+public:
+    template <typename ValueType>
+    static bool SetValue(property_base& prop, ValueType value)
+    {
+        using data_type_t = typename detail::data_type_map<ValueType>::value_type_t;
+
+        auto p = prop.cast<data_type_t>();
+        if (p == nullptr)
+            return false;
+
+        p->set_value(value);
+        return true;
+    };
+
+    template <typename ValueType>
+    static std::string value_to_string(const Property<ValueType>& prop)
+    {
+        if (!prop.get_value())
+            return {};
+
+        return std::to_string(*prop.get_value());
+    };
+
+    template <typename ValueType>
+    static bool set_value_from_string(Property<ValueType>& prop, util::string_view value)
+    {
+        std::istringstream sstream(value.to_string());
+
+        ValueType val;
+        sstream >> val;
+
+        if (sstream.fail())
+            return false;
+
+        prop.set_value(val);
+        return true;
+    };
+};
+
+template <>
+inline std::string PropertyHelper::value_to_string<std::string>(const Property<std::string>& prop)
+{
+    if (!prop.get_value())
+        return {};
+
+    return *prop.get_value();
+};
+
+template <>
+inline bool PropertyHelper::set_value_from_string<std::string>(Property<std::string>& prop, util::string_view value)
+{
+    prop.set_value(value.to_string());
+    return true;
+};
+
+template <typename T>
+const util::optional<std::string> Property<T>::get_value_as_string() const
+{
+    return PropertyHelper::value_to_string<T>(*this);
+};
+
+template <typename T>
+bool Property<T>::set_value_from_string(util::string_view value)
+{
+    return PropertyHelper::set_value_from_string<T>(*this, value);
 };
 
 }

--- a/src/libaas/basyx/submodelelement/submodelelement.cpp
+++ b/src/libaas/basyx/submodelelement/submodelelement.cpp
@@ -1,6 +1,23 @@
 #include "submodelelement.h"
 
+#include <basyx/submodelelement/property.h>
+#include <basyx/submodelelement/multilanguageproperty.h>
+#include <basyx/submodelelement/submodelelementcollection.h>
+
 namespace basyx
 {
+
+	bool SubmodelElementHelper::IsProperty(const SubmodelElement& ele) {
+		return SubmodelElement::is_element_type<property_base>(&ele);
+	};
+
+	bool SubmodelElementHelper::IsMultiLanguageProperty(const SubmodelElement& ele) {
+		return SubmodelElement::is_element_type<MultiLanguageProperty>(&ele);
+	};
+	
+	bool SubmodelElementHelper::IsSubmodelElementCollection(const SubmodelElement& ele)  {
+		return SubmodelElement::is_element_type<SubmodelElementCollection>(&ele);
+	};
+
 
 };

--- a/src/libaas/basyx/submodelelement/submodelelement.h
+++ b/src/libaas/basyx/submodelelement/submodelelement.h
@@ -33,10 +33,18 @@ public:
 	virtual ~SubmodelElement() = default;
 public:
 	template<typename submodel_element_t>
-	static bool is_element_type(SubmodelElement* sel) { return dynamic_cast<submodel_element_t*>(sel) != nullptr; }
+	static bool is_element_type(const SubmodelElement* sel) { return dynamic_cast<const submodel_element_t*>(sel) != nullptr; }
 
 	template<typename submodel_element_t>
 	static submodel_element_t* element_cast(SubmodelElement* sel) { return dynamic_cast<submodel_element_t*>(sel); }
+};
+
+class SubmodelElementHelper
+{
+public:
+	static bool IsProperty(const SubmodelElement& ele);
+	static bool IsMultiLanguageProperty(const SubmodelElement& ele);
+	static bool IsSubmodelElementCollection(const SubmodelElement& ele);
 };
 
 }

--- a/tests/tests_libaas/test_basyx.cpp
+++ b/tests/tests_libaas/test_basyx.cpp
@@ -145,38 +145,6 @@ TEST_F(BaseTest, HasKind)
     has_kind->kind = ModelingKind::Instance;
 };
 
-TEST_F(BaseTest, PropertyTest1)
-{
-    Property<int> p1 { "int_prop" };
-    p1.set_value(5);
-
-    ASSERT_EQ(*p1.get_value(), 5);
-    ASSERT_EQ(p1.get_value_type(), "int");
-
-    Property<float> p2 { "float_prop" };
-    ASSERT_EQ(p2.get_value_type(), "float");
-    ASSERT_FALSE(p2.get_value());
-
-    p2.set_value(5.0f);
-    ASSERT_TRUE(p2.get_value());
-    ASSERT_EQ(*p2.get_value(), 5.0f);
-};
-
-TEST_F(BaseTest, PropertyTest2)
-{
-    Property<int> p1 { "int_prop", 5 };
-    ASSERT_EQ(*p1.get_value(), 5);
-    ASSERT_EQ(p1.get_value_type(), "int");
-
-    Property<float> p2 { "float_prop", 5.0f };
-    ASSERT_TRUE(p2.get_value());
-    ASSERT_EQ(*p2.get_value(), 5.0f);
-
-    Property<std::string> p3 { "string_prop", "test" };
-    ASSERT_TRUE(p3.get_value());
-    ASSERT_EQ(*p3.get_value(), "test");
-};
-
 TEST_F(BaseTest, RangeTest)
 {
     Range<uint32_t> p1 { "int_prop" };
@@ -186,16 +154,6 @@ TEST_F(BaseTest, RangeTest)
     ASSERT_EQ(*p1.get_min(), 1);
     ASSERT_EQ(*p1.get_max(), 5);
     ASSERT_EQ(p1.get_value_type(), "unsignedInt");
-};
-
-TEST_F(BaseTest, PropertyType)
-{
-    ASSERT_EQ(Property<uint8_t> { "id" }.get_value_type(), "unsignedByte");
-    ASSERT_EQ(Property<int8_t> { "id" }.get_value_type(), "byte");
-    ASSERT_EQ(Property<std::string> { "id" }.get_value_type(), "string");
-    ASSERT_EQ(Property<double> { "id" }.get_value_type(), "double");
-    ASSERT_EQ(Property<float> { "id" }.get_value_type(), "float");
-    ASSERT_EQ(Property<char> { "id" }.get_value_type(), "byte");
 };
 
 TEST_F(BaseTest, SubmodelElement)
@@ -290,25 +248,6 @@ TEST_F(BaseTest, SubmodelElementCollection_CopyConstructor)
     ASSERT_EQ(col4->getIdShort(), "col1");
 };
 
-TEST_F(BaseTest, IntPropertyCopy)
-{
-    Property<int> i { "i", 1 };
-    auto i2 = i;
-
-    i2.~Property();
-    i.~Property();
-}
-
-TEST_F(BaseTest, StringProperty)
-{
-    Property<std::string> s { "string_prop", "test" };
-    auto s2 = s;
-
-    s.set_value("test");
-
-    s.~Property();
-    s2.~Property();
-}
 
 TEST_F(BaseTest, Submodel)
 {

--- a/tests/tests_libaas/test_property.cpp
+++ b/tests/tests_libaas/test_property.cpp
@@ -1,0 +1,176 @@
+#include <gtest/gtest.h>
+
+#include <basyx/key.h>
+#include <basyx/langstringset.h>
+#include <basyx/reference.h>
+#include <basyx/environment.h>
+#include <basyx/assetadministrationshell.h>
+#include <basyx/asset/asset.h>
+#include <basyx/asset/assetinformation.h>
+#include <basyx/submodel.h>
+
+#include <basyx/enums/IdentifiableElements.h>
+
+#include <basyx/constraints/qualifier.h>
+#include <basyx/constraints/formula.h>
+
+#include <basyx/submodelelement/multilanguageproperty.h>
+#include <basyx/submodelelement/property.h>
+#include <basyx/submodelelement/range.h>
+#include <basyx/submodelelement/submodelelementcollection.h>
+#include <basyx/submodelelement/entity.h>
+
+#include <type_traits>
+
+#include <basyx/base/basyx_enum_base.h>
+
+using namespace basyx;
+
+class PropertyTest : public ::testing::Test {
+protected:
+    // Test settings
+
+    // Test variables
+
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+
+TEST_F(PropertyTest, PropertyType)
+{
+    ASSERT_EQ(Property<uint8_t> { "id" }.get_value_type(), "unsignedByte");
+    ASSERT_EQ(Property<int8_t> { "id" }.get_value_type(), "byte");
+    ASSERT_EQ(Property<std::string> { "id" }.get_value_type(), "string");
+    ASSERT_EQ(Property<double> { "id" }.get_value_type(), "double");
+    ASSERT_EQ(Property<float> { "id" }.get_value_type(), "float");
+    ASSERT_EQ(Property<char> { "id" }.get_value_type(), "byte");
+};
+
+TEST_F(PropertyTest, PropertyTest1)
+{
+    Property<int> p1{ "int_prop" };
+    p1.set_value(5);
+
+    ASSERT_EQ(*p1.get_value(), 5);
+    ASSERT_EQ(p1.get_value_type(), "int");
+
+    Property<float> p2{ "float_prop" };
+    ASSERT_EQ(p2.get_value_type(), "float");
+    ASSERT_FALSE(p2.get_value());
+
+    p2.set_value(5.0f);
+    ASSERT_TRUE(p2.get_value());
+    ASSERT_EQ(*p2.get_value(), 5.0f);
+};
+
+TEST_F(PropertyTest, PropertyTest2)
+{
+    Property<int> p1{ "int_prop", 5 };
+    ASSERT_EQ(*p1.get_value(), 5);
+    ASSERT_EQ(p1.get_value_type(), "int");
+
+    Property<float> p2{ "float_prop", 5.0f };
+    ASSERT_TRUE(p2.get_value());
+    ASSERT_EQ(*p2.get_value(), 5.0f);
+
+    Property<std::string> p3{ "string_prop", "test" };
+    ASSERT_TRUE(p3.get_value());
+    ASSERT_EQ(*p3.get_value(), "test");
+};
+
+
+TEST_F(PropertyTest, IntPropertyCopy)
+{
+    Property<int> i{ "i", 1 };
+    auto i2 = i;
+
+    i2.~Property();
+    i.~Property();
+}
+
+TEST_F(PropertyTest, StringPropertyCopy)
+{
+    Property<std::string> s{ "string_prop", "test" };
+    auto s2 = s;
+
+    s.set_value("test");
+
+    s.~Property();
+    s2.~Property();
+}
+
+TEST_F(PropertyTest, PropertyCast)
+{
+    Property<int> i{ "i", 1 };
+    property_base* base_prop = &i;
+
+    auto casted_ok = base_prop->cast<int>();
+    ASSERT_NE(casted_ok, nullptr);
+    ASSERT_EQ(casted_ok->get_value(), i.get_value());
+
+    auto casted_bad = base_prop->cast<std::string>();
+    ASSERT_EQ(casted_bad, nullptr);
+}
+
+TEST_F(PropertyTest, SetValueHelper)
+{
+    // Integer
+    Property<int> i{ "i", 1 };
+    PropertyHelper::SetValue(i, 5);
+    ASSERT_EQ(i.get_value(), 5);
+
+    // Float
+    Property<float> f{ "f", 1.0f };
+    PropertyHelper::SetValue(f, 0.0f);
+    ASSERT_EQ(f.get_value(), 0.0f);
+
+    // String
+    Property<std::string> s{ "str", "test" };
+    PropertyHelper::SetValue(s, "basyx");
+    ASSERT_EQ(s.get_value(), "basyx");
+}
+
+TEST_F(PropertyTest, GetStringValue)
+{
+    // Integer
+    Property<int> i{ "i", 1 };
+    ASSERT_EQ(i.get_value_as_string(), "1");
+
+    // Float
+    Property<float> f{ "f", 1.0f };
+    ASSERT_EQ(f.get_value_as_string(), std::to_string(1.0f));
+
+    // String
+    Property<std::string> s{ "str", "test" };
+    ASSERT_EQ(s.get_value_as_string(), "test");
+};
+
+
+TEST_F(PropertyTest, SetStringValue)
+{
+    // Integer
+    Property<int> i{ "i", 1 };
+    i.set_value_from_string("2");
+    ASSERT_EQ(i.get_value(), 2);
+
+    // Integer - Error
+    Property<int> i2{ "i", 1 };
+    ASSERT_FALSE(i2.set_value_from_string("test"));
+    ASSERT_EQ(i2.get_value(), 1);
+
+    // Float
+    Property<float> f{ "f", 1.0f };
+    f.set_value_from_string("2.0000");
+    ASSERT_EQ((int)*f.get_value(), 2);
+
+    // String
+    Property<std::string> s{ "str", "test" };
+    s.set_value_from_string("basyx");
+    ASSERT_EQ(s.get_value(), "basyx");
+}


### PR DESCRIPTION
Adds some utility methods and associated tests for easier value retrieval and setting of Properties, especially in contexts where the actual Property ValueType is unknown at runtime.

Required for PUT functionality of the REST server in basyx-cpp-components.