### PR TITLE
RFC: Add enums for template referenciation

### DIFF
--- a/src/libaas/basyx/base/valuetypedefs.cpp
+++ b/src/libaas/basyx/base/valuetypedefs.cpp
@@ -1,0 +1,36 @@
+#include <basyx/base/valuetypedefs.h>
+
+namespace basyx::detail {
+
+util::string_view toString(const datatypes valuetype) {
+   switch (valuetype) {
+   case Boolean:
+      return "boolean";
+   case Byte:
+      return "byte";
+   case UnsignedByte:
+      return "unsignedByte";
+   case Short:
+      return "short";
+   case UnsignedShort:
+      return "unsignedShort";
+   case Integer:
+      return "int";
+   case UnsignedInteger:
+      return "unsignedInt";
+   case Long:
+      return "long";
+   case UnsignedLong:
+      return "unsignedLong";
+   case Float:
+      return "float";
+   case Double:
+      return "double";
+   case String:
+      return "string";
+   default:
+      /* unreachable */
+      return "string";
+   }
+}
+}

--- a/src/libaas/basyx/base/valuetypedefs.h
+++ b/src/libaas/basyx/base/valuetypedefs.h
@@ -1,3 +1,6 @@
+#ifndef VALUETYPEDEFS_H
+#define VALUETYPEDEFS_H
+
 #pragma once
 
 #include <cstdint>
@@ -9,20 +12,39 @@ namespace basyx {
 namespace detail
 {
 
-	template<typename T> struct data_type_def {};
-	template<> struct data_type_def<int8_t> { static constexpr char value_type[] = "byte"; };
-	template<> struct data_type_def<char> { static constexpr char value_type[] = "byte"; };
-	template<> struct data_type_def<uint8_t> { static constexpr char value_type[] = "unsignedByte"; };
-	template<> struct data_type_def<int16_t> { static constexpr char value_type[] = "short"; };
-	template<> struct data_type_def<uint16_t> { static constexpr char value_type[] = "unsignedShort"; };
-	template<> struct data_type_def<int32_t> { static constexpr char value_type[] = "int"; };
-	template<> struct data_type_def<uint32_t> { static constexpr char value_type[] = "unsignedInt"; };
-	template<> struct data_type_def<int64_t> { static constexpr char value_type[] = "long"; };
-	template<> struct data_type_def<uint64_t> { static constexpr char value_type[] = "unsignedLong"; };
-	template<> struct data_type_def<float> { static constexpr char value_type[] = "float"; };
-	template<> struct data_type_def<double> { static constexpr char value_type[] = "double"; };
-	template<> struct data_type_def<bool> { static constexpr char value_type[] = "boolean"; };
-	template<> struct data_type_def<std::string> { static constexpr char value_type[] = "string"; };
+enum datatypes {
+   Boolean = 0,
+   Byte,
+   UnsignedByte,
+   Short,
+   UnsignedShort,
+   Integer,
+   UnsignedInteger,
+   Long,
+   UnsignedLong,
+   Float,
+   Double,
+   String,
+};
+
+util::string_view toString(const datatypes valuetype);
+
+   template<typename T> struct data_type_def {
+   datatypes value_type;
+};
+   template<> struct data_type_def<int8_t> { static constexpr datatypes value_type = Byte; };
+   template<> struct data_type_def<char> { static constexpr datatypes value_type = Byte; };
+   template<> struct data_type_def<uint8_t> { static constexpr datatypes value_type = UnsignedByte; };
+   template<> struct data_type_def<int16_t> { static constexpr datatypes value_type = Short; };
+   template<> struct data_type_def<uint16_t> { static constexpr datatypes value_type = UnsignedShort; };
+   template<> struct data_type_def<int32_t> { static constexpr datatypes value_type = Integer; };
+   template<> struct data_type_def<uint32_t> { static constexpr datatypes value_type = UnsignedInteger; };
+   template<> struct data_type_def<int64_t> { static constexpr datatypes value_type = Long; };
+   template<> struct data_type_def<uint64_t> { static constexpr datatypes value_type = UnsignedLong; };
+   template<> struct data_type_def<float> { static constexpr datatypes value_type = Float; };
+   template<> struct data_type_def<double> { static constexpr datatypes value_type = Double; };
+   template<> struct data_type_def<bool> { static constexpr datatypes value_type = Boolean; };
+   template<> struct data_type_def<std::string> { static constexpr datatypes value_type = String; };
 
 	template<typename T> struct data_type_map { using value_type_t = T; };
 	template<> struct data_type_map<std::string> { using value_type_t = std::string; };
@@ -31,3 +53,5 @@ namespace detail
 
 };
 }
+
+#endif // VALUETYPEDEFS_H

--- a/src/libaas/basyx/constraints/qualifier.cpp
+++ b/src/libaas/basyx/constraints/qualifier.cpp
@@ -2,8 +2,4 @@
 
 namespace basyx
 {
-
-qualifier_base::~qualifier_base() {};
-
-
 };

--- a/src/libaas/basyx/constraints/qualifier.h
+++ b/src/libaas/basyx/constraints/qualifier.h
@@ -1,3 +1,6 @@
+#ifndef QUALIFIER_H
+#define QUALIFIER_H
+
 #pragma once
 
 #include <basyx/base/valuetypedefs.h>
@@ -10,48 +13,72 @@
 
 #include <basyx/util/optional/optional.hpp>
 
+#include <basyx/serialization/serializable.h>
+
 namespace basyx
 {
 
 class qualifier_base : 
 	public Constraint,
-	public HasSemantics,
 	private ModelType<ModelTypes::Qualifier>
 {
 public:
 	qualifier_base() = default;
-	virtual ~qualifier_base() = 0;
+   virtual ~qualifier_base() = default;
 public:
 	virtual util::string_view getValueType() const = 0;
 };
 
+class QualifierBase: public qualifier_base {
+   basyx::detail::datatypes type;
+public:
+   QualifierBase(basyx::detail::datatypes type): type(type) {}
+   ~QualifierBase() = default;
+
+   util::string_view getValueType() const override { return basyx::detail::toString(type); }
+   basyx::detail::datatypes getValueTypeEnum() { return type; }
+
+   template <typename DataType>
+   Qualifier<DataType>* cast() { return dynamic_cast<Qualifier<DataType>*>(this); };
+};
+
 template<typename ValueType>
-class Qualifier : public qualifier_base
-{
+class Qualifier : public QualifierBase {
 public:
 	using modeltype_base::get_model_type;
 private:
-	std::string qualifierType;
+   std::string qualifierType;
 	util::optional<Reference> valueId;
 	util::optional<ValueType> value;
 public:
-	Qualifier(util::string_view qualifierType) : qualifierType(qualifierType.to_string()) {};
+   Qualifier(util::string_view qualifierType) :
+      QualifierBase(detail::data_type_def<ValueType>::value_type),
+      qualifierType(qualifierType.to_string()) {
+   }
 
 	template<typename U = ValueType>
-	Qualifier(util::string_view qualifierType, U && u) : qualifierType(qualifierType.to_string()), value(std::forward<U>(u)) {};
+   Qualifier(util::string_view qualifierType, U && u) :
+      QualifierBase(detail::data_type_def<ValueType>::value_type),
+      qualifierType(qualifierType.to_string()),
+      value(std::forward<U>(u)) {
+   }
 
-	Qualifier(const Qualifier&) = default;
+   Qualifier(const Qualifier&) = default;
 	Qualifier& operator=(const Qualifier&) = default;
 
 	Qualifier(Qualifier&&) = default;
 	Qualifier& operator=(Qualifier&&) = default;
 
-	~Qualifier() = default;
+   ~Qualifier() = default;
 public:
-	const std::string & getQualifierType() const { return qualifierType; };
-	void setQualifierType(util::string_view qualifierType) { this->qualifierType = qualifierType.to_string(); };
+   std::string & getQualifierType() { return qualifierType; };
+   void setQualifierType(util::string_view qualifierType) {
+      this->qualifierType = qualifierType.to_string();
+   };
 
-	util::string_view getValueType() const override { return detail::data_type_def<ValueType>::value_type; };
+   /*util::string_view getValueType() const override {
+      return basyx::detail::toString(detail::data_type_def<ValueType>::value_type);
+   }*/
 
 	const util::optional<ValueType> & getValue() const { return this->value; };
 
@@ -62,3 +89,5 @@ public:
 };
 
 }
+
+#endif // QUALIFIER_H

--- a/src/libaas/basyx/serialization/json/serializer_fwd.h
+++ b/src/libaas/basyx/serialization/json/serializer_fwd.h
@@ -33,6 +33,9 @@ namespace basyx
 
 	template<typename T>
 	class Property;
+
+   template<typename T>
+   class Qualifier;
 };
 
 
@@ -65,7 +68,7 @@ namespace basyx::serialization::json
 	void serialize_helper(json_t & json, const Blob&);
 	void serialize_helper(json_t & json, const SubmodelElementCollection&);
 	void serialize_helper(json_t & json, const AssetAdministrationShell&);
-	
+
 	template<typename T>
 	void serialize_helper(json_t & json, const Property<T>& prop);
 };

--- a/src/libaas/basyx/submodelelement/property.h
+++ b/src/libaas/basyx/submodelelement/property.h
@@ -70,7 +70,10 @@ public:
     const util::optional<Reference>& get_value_id() const override { return this->valueId; }
     void set_value_id(const Reference& reference) override { this->valueId = reference; };
 
-    util::string_view get_value_type() const override { return detail::data_type_def<DataType>::value_type; };
+    util::string_view get_value_type() const override {
+       util::string_view typeStr = detail::toString(detail::data_type_def<DataType>::value_type);
+       return typeStr;
+    };
 
     const util::optional<DataType>& get_value() const { return this->value; };
 

--- a/src/libaas/basyx/submodelelement/range.h
+++ b/src/libaas/basyx/submodelelement/range.h
@@ -37,7 +37,8 @@ public:
 	const util::optional<DataType> & get_max() const { return this->max; };
 	util::optional<DataType> & get_max() { return this->max; };
 
-	util::string_view get_value_type() const { return detail::data_type_def<DataType>::value_type; };
+   util::string_view get_value_type() const {
+      return detail::toString(detail::data_type_def<DataType>::value_type); };
 
 	template<typename U = DataType>
 	void set_min(U && value) {

--- a/src/libaas/sources.cmake
+++ b/src/libaas/sources.cmake
@@ -5,6 +5,7 @@ SET(SOURCE_FILES_BASYX_AAS
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/assetadministrationshell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/base/basyx_enums.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/base/token.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/basyx/base/valuetypedefs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/constraints/constraint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/constraints/formula.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/basyx/constraints/qualifier.cpp

--- a/tests/tests_libaas/test_qualifier.cpp
+++ b/tests/tests_libaas/test_qualifier.cpp
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+
+#include <basyx/key.h>
+#include <basyx/langstringset.h>
+#include <basyx/reference.h>
+#include <basyx/environment.h>
+#include <basyx/assetadministrationshell.h>
+#include <basyx/asset/asset.h>
+#include <basyx/asset/assetinformation.h>
+#include <basyx/submodel.h>
+
+#include <basyx/enums/IdentifiableElements.h>
+
+#include <basyx/constraints/qualifier.h>
+#include <basyx/constraints/formula.h>
+
+#include <basyx/base/basyx_enum_base.h>
+
+using namespace basyx;
+
+class QualifierTest : public ::testing::Test {
+protected:
+    // Test settings
+
+    // Test variables
+
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+
+TEST_F(QualifierTest, QualifierType)
+{
+    ASSERT_EQ(Qualifier<uint8_t> { "id" }.getValueType(), "unsignedByte");
+    ASSERT_EQ(Qualifier<int8_t> { "id" }.getValueType(), "byte");
+    ASSERT_EQ(Qualifier<std::string> { "id" }.getValueType(), "string");
+    ASSERT_EQ(Qualifier<double> { "id" }.getValueType(), "double");
+    ASSERT_EQ(Qualifier<float> { "id" }.getValueType(), "float");
+    ASSERT_EQ(Qualifier<char> { "id" }.getValueType(), "byte");
+};
+
+TEST_F(QualifierTest, QualifierTest1)
+{
+    Qualifier<int> q1{ "int_qual" };
+    q1.setValue(5);
+
+    ASSERT_EQ(*q1.getValue(), 5);
+    ASSERT_EQ(q1.getValueType(), "int");
+
+    Qualifier<float> p2{ "float_qualifier" };
+    ASSERT_EQ(p2.getValueType(), "float");
+    ASSERT_FALSE(p2.getValue());
+
+    p2.setValue(5.0f);
+    ASSERT_TRUE(p2.getValue());
+    ASSERT_EQ(*p2.getValue(), 5.0f);
+};
+
+TEST_F(QualifierTest, QualifierTest2)
+{
+    Qualifier<int> q1{ "int_qualifier", 5 };
+    ASSERT_EQ(*q1.getValue(), 5);
+    ASSERT_EQ(q1.getValueType(), "int");
+
+    Qualifier<float> q2{ "float_qualifier", 5.0f };
+    ASSERT_TRUE(q2.getValue());
+    ASSERT_EQ(*q2.getValue(), 5.0f);
+
+    Qualifier<std::string> q3{ "string_qualifier", "test" };
+    ASSERT_TRUE(q3.getValue());
+    ASSERT_EQ(*q3.getValue(), "test");
+};
+
+
+TEST_F(QualifierTest, IntQualifierCopy)
+{
+    Qualifier<int> i{ "i", 1 };
+    auto i2 = i;
+
+    i2.~Qualifier();
+    i.~Qualifier();
+}
+
+TEST_F(QualifierTest, StringQualifierCopy)
+{
+    Qualifier<std::string> s("stringType");
+    s.setValue("testStart");
+    auto s2 = s;
+
+    s.setValue("test");
+
+    s.~Qualifier();
+    s2.~Qualifier();
+}
+
+TEST_F(QualifierTest, QualifierTypeTest)
+{
+    std::string s = "string_qualifier";
+
+    Qualifier<std::string> qs{ "string_qualifier", "test" };
+    ASSERT_EQ(qs.getQualifierType(), s);
+
+    auto qs2 = qs;
+
+    ASSERT_EQ(qs2.getQualifierType(), s);
+}
+
+TEST_F(QualifierTest, StringQualifierInitializerListCopy)
+{
+    Qualifier<std::string> s{ "string_qualifier", "testStart" };
+    auto s2 = s;
+
+    s.setValue("test");
+}
+
+TEST_F(QualifierTest, QualifierCast)
+{
+    Qualifier<int> i{ "i", 1 };
+    QualifierBase* baseQual = &i;
+
+    auto casted_ok = baseQual->cast<int>();
+    ASSERT_NE(casted_ok, nullptr);
+    ASSERT_EQ(casted_ok->getValue(), i.getValue());
+
+    auto casted_bad = baseQual->cast<std::string>();
+    ASSERT_EQ(casted_bad, nullptr);
+}
+
+TEST_F(QualifierTest, QualifierTypeInfo)
+{
+    int intVal = 1;
+    Qualifier<int> i{ "i", intVal };
+    QualifierBase* baseQual = &i;
+
+    ASSERT_EQ(baseQual->getValueType(), "int");
+
+    switch (baseQual->getValueTypeEnum()) {
+    case basyx::detail::Integer: {
+       Qualifier<int> *i2= baseQual->cast<int>();
+       ASSERT_EQ(i2->getValue(), intVal);
+       break;
+    }
+    default:
+       break;
+    }
+}
+
+


### PR DESCRIPTION
With this we can create base classes, as seen with the qualifiers, where we can cast to and cast back later on by using the information from the base class