### PR TITLE
MinMaxString: Add *operator for assigning std::MinMaxString

### DIFF
--- a/src/libaas/basyx/base/minMaxString.cpp
+++ b/src/libaas/basyx/base/minMaxString.cpp
@@ -15,6 +15,11 @@ MinMaxString &MinMaxString::operator=(const MinMaxString &str) noexcept {
    return *this;
 }
 
+std::string MinMaxString::operator*() noexcept {
+   return this->str();
+
+}
+
 MinMaxString &MinMaxString::operator=(const basyx::util::string_view& str) noexcept {
    replace(str.to_string());
    return *this;

--- a/src/libaas/basyx/base/minMaxString.h
+++ b/src/libaas/basyx/base/minMaxString.h
@@ -36,6 +36,7 @@ public:
    MinMaxString& operator=(const MinMaxString& str) noexcept;
    MinMaxString& operator=(const basyx::util::string_view& str) noexcept;
    MinMaxString& operator=(const std::string& str) noexcept;
+   std::string operator*() noexcept;
    //MinMaxString& operator=(MinMaxString &) noexcept = default;
 
    bool operator==(const std::string& rhs) {

--- a/tests/tests_libaas/test_basyx.cpp
+++ b/tests/tests_libaas/test_basyx.cpp
@@ -53,7 +53,7 @@ TEST_F(BaseTest, MinMaxString) {
    ASSERT_EQ(min, mmStr.length());
    std::string cmp;
    cmp+= base::STRING_PADDING;
-   ASSERT_STREQ(cmp.data(), mmStr.str().data());
+   ASSERT_STREQ(cmp.data(), (*mmStr).data());
 
    // Check if max size is honored
    base::MinMaxString mmStr2(min, max);
@@ -77,6 +77,10 @@ TEST_F(BaseTest, MinMaxString) {
    mmStr5.assign(ste);
    ASSERT_STREQ(ste.data(), mmStr5.str().data());
 
+
+   base::MinMaxString mmStr6(min, max);
+   mmStr6.assign("bla");
+   std::string base = *mmStr6;
 }
 
 TEST_F(BaseTest, VersionRevisionType)


### PR DESCRIPTION
As a blueprint for assiging std::string from other classes like Identifier. This works similar to iterators.